### PR TITLE
:arrow_up: Updated auth restricted pages

### DIFF
--- a/components/app/LeftMenu.vue
+++ b/components/app/LeftMenu.vue
@@ -30,7 +30,7 @@
         </n-link>
       </a-menu-item>
 
-      <a-sub-menu key="favoritos">
+      <a-sub-menu v-if="$auth.loggedIn" key="favoritos">
         <span slot="title">
           <a-icon type="heart" />
           <span>Favoritos</span>
@@ -47,7 +47,7 @@
         </a-sub-menu>
       </a-sub-menu>
 
-      <a-menu-item class="last" @click="$auth.logout()">
+      <a-menu-item v-if="$auth.loggedIn" class="last" @click="$auth.logout()">
         <a-icon type="logout" />
         <span>Logout</span>
       </a-menu-item>
@@ -59,7 +59,9 @@
 export default {
   computed: {
     favoriteProposicoes() {
-      return this.$auth.user.favorite_proposicoes;
+      return (
+        (this.$auth.loggedIn && this.$auth.user.favorite_proposicoes) || []
+      );
     }
   }
 };

--- a/components/app/TopMenu.vue
+++ b/components/app/TopMenu.vue
@@ -1,19 +1,26 @@
 <template>
   <a-menu
+    id="top-menu"
     mode="horizontal"
     theme="light"
     :style="{ boxShadow: '0 -4px 10px #1890ff' }"
     :default-selected-keys="[$nuxt.$route.name]"
-    id="top-menu"
   >
-    <a-menu-item class="item-right" key="profile">
+    <a-menu-item v-if="$auth.loggedIn" key="profile" class="item-right">
       <n-link to="/profile">
         <a-icon type="user" />
         Perfil
       </n-link>
     </a-menu-item>
 
-    <a-menu-item class="item-right" key="notifications" v-if="false">
+    <a-menu-item v-else key="login" class="item-right">
+      <n-link to="/login">
+        <a-icon type="user" />
+        Login
+      </n-link>
+    </a-menu-item>
+
+    <a-menu-item v-if="false" key="notifications" class="item-right">
       <a-icon type="bell" />
       Notificaçōes
     </a-menu-item>

--- a/components/app/proposicoes/ProposicaoListItem.vue
+++ b/components/app/proposicoes/ProposicaoListItem.vue
@@ -1,6 +1,7 @@
 <template>
   <a-list-item>
     <a-button
+      v-if="$auth.loggedIn"
       icon="bell"
       slot="actions"
       @click="subscriptionHandle"
@@ -10,6 +11,7 @@
     >
     </a-button>
     <a-button
+      v-if="$auth.loggedIn"
       icon="heart"
       slot="actions"
       :ghost="!favorite"
@@ -27,7 +29,7 @@
 
     <a-list-item-meta :description="proposicao.ementa">
       <h3 slot="title">
-        {{ this.proposicaoNome }}
+        {{ proposicaoNome }}
         {{ proposicao.ano || 'Ano desconhecido' }}
       </h3>
     </a-list-item-meta>
@@ -54,13 +56,20 @@ export default {
   },
   computed: {
     favorite() {
-      return this.$auth.user.favorite_proposicoes.find(
-        (p) => p.proposicao_id === this.proposicao.id
+      return (
+        this.$auth.loggedIn &&
+        this.$auth.user.favorite_proposicoes.find(
+          (p) => p.proposicao_id === this.proposicao.id
+        )
       );
     },
     subscribed() {
-      return this.$auth.user.subscriptions?.find(
-        (s) => s.external_model === 'P' && s.external_id === this.proposicao.id
+      return (
+        this.$auth.loggedIn &&
+        this.$auth.user.subscriptions?.find(
+          (s) =>
+            s.external_model === 'P' && s.external_id === this.proposicao.id
+        )
       );
     },
     proposicaoNome() {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -6,13 +6,19 @@
       class="menu"
       :default-selected-keys="[$nuxt.$route.name]"
     >
-      <a-menu-item class="item-right" key="login">
-        <n-link :to="loginRoute">
+      <a-menu-item v-if="!$auth.loggedIn" key="login" class="item-right">
+        <n-link to="/login">
           Login
         </n-link>
       </a-menu-item>
 
-      <a-menu-item class="item-right" key="index">
+      <a-menu-item key="proposicoes" class="item-right">
+        <n-link to="/proposicoes">
+          Proposicoes
+        </n-link>
+      </a-menu-item>
+
+      <a-menu-item key="index" class="item-right">
         <n-link to="/">
           Home
         </n-link>
@@ -23,16 +29,7 @@
 </template>
 
 <script>
-export default {
-  computed: {
-    loginRoute() {
-      if (this.$auth.loggedIn) {
-        return '/proposicoes';
-      }
-      return '/login';
-    }
-  }
-};
+export default {};
 </script>
 
 <style>

--- a/pages/deputados/index.vue
+++ b/pages/deputados/index.vue
@@ -5,9 +5,9 @@
         v-model="query"
         style="width: 400px"
         placeholder="Procurar por deputado"
-        @select="setSelectedDeputado"
         label=""
         allowClear
+        @select="setSelectedDeputado"
       >
         <template slot="dataSource">
           <a-select-option
@@ -41,8 +41,8 @@
         <br />
         <a-button
           v-if="notSubscribed"
-          @click="subscribe"
           :disabled="subscriptionLoading"
+          @click="subscribe"
           ><a-icon type="bell" />Ativar notificaçōes</a-button
         >
         <a-alert v-else type="info" description="Notificaçōes ativas" />
@@ -77,10 +77,10 @@
                 show-icon
               />
               <proposicao-list-item
-                v-else
                 v-for="(prop, idx) in proposicao"
-                :proposicao="prop"
+                v-else
                 :key="idx"
+                :proposicao="prop"
               >
               </proposicao-list-item>
             </a-list>
@@ -98,6 +98,7 @@ import ProposicaoListItem from '~/components/app/proposicoes/ProposicaoListItem'
 import DeputadoSpeeches from '~/components/app/deputados/DeputadoSpeeches';
 
 export default {
+  auth: false,
   layout: 'auth',
   components: {
     DeputadoCard,
@@ -125,6 +126,7 @@ export default {
     },
     notSubscribed() {
       if (
+        this.$auth.loggedIn &&
         this.$auth.user.subscriptions.find(
           (s) =>
             s.external_model === 'D' &&

--- a/pages/eventos/_id.vue
+++ b/pages/eventos/_id.vue
@@ -88,6 +88,7 @@
 import DeputadoCard from '~/components/app/deputados/DeputadoCard';
 import ProposicaoListItem from '~/components/app/proposicoes/ProposicaoListItem';
 export default {
+  auth: false,
   layout: 'auth',
   components: {
     DeputadoCard,

--- a/pages/eventos/index.vue
+++ b/pages/eventos/index.vue
@@ -23,6 +23,7 @@
 </template>
 <script>
 export default {
+  auth: false,
   layout: 'auth',
   async fetch() {
     const today = this.$moment();

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -109,7 +109,7 @@ export default {
   },
   computed: {
     subscriptions() {
-      return this.$auth.user.subscriptions;
+      return (this.$auth.loggedIn && this.$auth.user.subscriptions) || [];
     },
     subProposicoes() {
       return this.subscriptions.filter((s) => s.external_model === 'P');

--- a/pages/proposicoes/_id.vue
+++ b/pages/proposicoes/_id.vue
@@ -99,6 +99,7 @@ import TramitacaoCard from '~/components/app/proposicoes/TramitacaoCard';
 import ProposicaoListItem from '~/components/app/proposicoes/ProposicaoListItem';
 
 export default {
+  auth: false,
   layout: 'auth',
   components: {
     TramitacaoCard,

--- a/pages/proposicoes/index.vue
+++ b/pages/proposicoes/index.vue
@@ -12,7 +12,7 @@
         <a-divider />
 
         <div class="lista-proposicoes">
-          <a-spin size="large" v-if="loading" />
+          <a-spin v-if="loading" size="large" />
           <a-alert
             v-if="!loading && !proposicoes.length"
             description="Nenhum resultado para pesquisa."
@@ -29,9 +29,9 @@
           <br />
           <br />
           <br />
-          <a-button v-if="nextPage" block type="primary" @click="loadMore"
-            >Carregar mais</a-button
-          >
+          <a-button v-if="nextPage" block type="primary" @click="loadMore">
+            Carregar mais
+          </a-button>
         </div>
       </section>
     </template>
@@ -43,6 +43,7 @@ import ProposicaoSearch from '~/components/app/proposicoes/ProposicaoSearch';
 import ProposicaoListItem from '~/components/app/proposicoes/ProposicaoListItem';
 
 export default {
+  auth: false,
   layout: 'auth',
   components: {
     ProposicaoSearch,


### PR DESCRIPTION
Refactored the dashboard to be able to use w/o being logged in.
Hide loggeding related buttons and actions
Updated menus to reflect if the user is logged in or not
Removed auth middleware from dashboard pages

Some props order were chaged due to lint warnings

Fixes: #14 

### Home header not logged in
![image](https://user-images.githubusercontent.com/6561278/95579461-0eda3980-0a0c-11eb-93a6-39401ac55e56.png)

### Dashboard menus not logged in
![image](https://user-images.githubusercontent.com/6561278/95579505-287b8100-0a0c-11eb-9871-4f5fcac2f2d1.png)

### Dashboard menus logged in
![image](https://user-images.githubusercontent.com/6561278/95579535-37faca00-0a0c-11eb-85a4-f359be05506d.png)

