### PR TITLE
:bulb: Add desc order on Deputados last events

### DIFF
--- a/pages/deputados/index.vue
+++ b/pages/deputados/index.vue
@@ -210,7 +210,9 @@ export default {
       );
       this.speeches = resSpeeches.dados;
 
-      const resEvents = await this.$openData.$get(`/deputados/${id}/eventos`);
+      const resEvents = await this.$openData.$get(
+        `/deputados/${id}/eventos?ordem=desc&ordenarPor=dataHoraInicio`
+      );
       this.events = resEvents.dados;
 
       const resProp = await this.$openData.$get(


### PR DESCRIPTION
Added Order by desc on Deputados events.
Previously it was asc by default.
Solves #41 