### PR TITLE
Fix cards of participants of event

### DIFF
--- a/components/app/deputados/DeputadoCard.vue
+++ b/components/app/deputados/DeputadoCard.vue
@@ -33,7 +33,10 @@
       <div>
         <p><b>Estado: </b>{{ deputado.siglaUf }}</p>
         <p><b>Partido: </b>{{ fullInfo.ultimoStatus.siglaPartido }}</p>
-        <p><b>Email: </b>{{ deputado.email }}</p>
+        <a-tooltip>
+          <template slot="title">{{ deputado.email }}</template>
+          <p class="email"><b>Email: </b>{{ deputado.email }}</p>
+        </a-tooltip>
         <p>
           <b>Telefone Gabinete: </b
           >{{ fullInfo.ultimoStatus.gabinete.telefone }}
@@ -112,3 +115,10 @@ export default {
   }
 };
 </script>
+<style scoped>
+.email {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+</style>

--- a/pages/deputados/index.vue
+++ b/pages/deputados/index.vue
@@ -210,7 +210,9 @@ export default {
       );
       this.speeches = resSpeeches.dados;
 
-      const resEvents = await this.$openData.$get(`/deputados/${id}/eventos`);
+      const resEvents = await this.$openData.$get(
+        `/deputados/${id}/eventos?ordem=desc&ordenarPor=dataHoraInicio`
+      );
       this.events = resEvents.dados;
 
       const resProp = await this.$openData.$get(


### PR DESCRIPTION
Now the cards are always the same size, and do not have the bug anymore.
For this, when the email is too big, it does not break line anymore, it was added ellipsis to the text.
They look like this:

<img width="1018" alt="Screenshot 2021-10-13 at 14 43 22" src="https://user-images.githubusercontent.com/62898120/137134840-08c0db12-d66c-4ecc-a6f3-76ea31e0daa4.png">
Solves #9 